### PR TITLE
return yaml value for find

### DIFF
--- a/src/jekyll_format.ml
+++ b/src/jekyll_format.ml
@@ -36,11 +36,8 @@ let result_to_exn = function
   | Ok r -> r
   | Error (`Msg m) -> raise (Parse_failure m)
 
-let find_yaml key f =
-  List.assoc_opt key f
-
 let find key f =
-  List.assoc_opt key f |> Option.map Ezjsonm.value_to_string
+  List.assoc_opt key f
 
 let keys f =
   List.map (fun (k,_) -> k) f
@@ -157,8 +154,8 @@ let slug_of_string s =
 let title ?fname f =
   let open R.Infix in
   match find "title" f with
-  | Some t -> Ok t
-  | None ->
+  | Some `String t -> Ok t
+  | _ ->
       match fname with
       | None -> R.error_msg "Unable to find a title key or parse the filename for it"
       | Some fname -> parse_filename fname >>| fun (_,title,_) -> title
@@ -166,15 +163,15 @@ let title ?fname f =
 let date ?fname f =
   let open R.Infix in
   match (find "date" f), fname with
-  | Some d, _ -> parse_date ~and_time:true d
-  | None, Some fname -> parse_filename fname >>| fun (date,_,_) -> date
-  | None, None -> R.error_msg "Unable to find a date key or parse the filename for it"
+  | Some `String d, _ -> parse_date ~and_time:true d
+  | _, Some fname -> parse_filename fname >>| fun (date,_,_) -> date
+  | _, None -> R.error_msg "Unable to find a date key or parse the filename for it"
 
 let slug ?fname f =
   let open R.Infix in
   match (find "slug" f) with
-  | Some s -> R.ok (slug_of_string s)
-  | None -> (* query filename instead *)
+  | Some `String s -> R.ok (slug_of_string s)
+  | _ -> (* query filename instead *)
      match fname with
      | Some fname -> parse_filename fname >>| fun (_,title,_) -> slug_of_string title
      | None ->

--- a/src/jekyll_format.mli
+++ b/src/jekyll_format.mli
@@ -25,16 +25,10 @@ val body : t -> body
 
 (** {1 YAML metadata} *)
 
-val find_yaml : string -> fields -> Yaml.value option
+val find : string -> fields -> Yaml.value option
 (** [find key t] retrieves the first [key] from the YAML front matter, and
     [None] if the key is not present. Keys are case-sensitive as per the
     YAML specification.  Whitespace is trimmed around the field value. *)
-
-val find : string -> fields -> string option
-(** [find key t] retrieves the first [key] from the YAML front matter, and
-    [None] if the key is not present. Keys are case-sensitive as per the
-    YAML specification.  Whitespace is trimmed around the field value,
-    and any Yaml contents are converted to a string representation. *)
 
 val keys : fields -> string list
 (** [keys f] retrieves all of the key names in the YAML front matter. *)

--- a/test/2015-04-02-ocamllabs-2014-review.md
+++ b/test/2015-04-02-ocamllabs-2014-review.md
@@ -2,6 +2,7 @@
 layout: post
 title: Reviewing the second year of OCaml Labs in 2014
 author: Anil Madhavapeddy
+date: 2014-04-24 17:14:07
 tags: ocamllabs,ocaml
 source: http://www.cl.cam.ac.uk/projects/ocamllabs/news/index.html
 source_name: OCaml Labs

--- a/test/simple.md
+++ b/test/simple.md
@@ -2,6 +2,10 @@
 alice: 111
 bob: 222
 charlie: 333
+dave: 
+  - a
+  - b
+eve: four-hundred and forty-four
 ---
 
 body


### PR DESCRIPTION
This PR changes the semantics of `Jekyll_format.find` from returning `string option` to `Yaml.value option`. This is in line with [the specification for Jekyll frontmatter](https://jekyllrb.com/docs/front-matter/). 

This impacts the predefined field getters like `title` and `date` but only in changing the pattern-matching to get `` `String data`` for example.

Finally I added a few tests like end-to-end date parsing and some more complex Yaml parsing. 